### PR TITLE
dev-tilgang til rekrutteringsbistand-kandidatvarsel-api

### DIFF
--- a/dev-gcp/aapen-brukervarsel.yaml
+++ b/dev-gcp/aapen-brukervarsel.yaml
@@ -108,3 +108,6 @@ spec:
     - team: farskapsportal
       application: farskapsportal-api
       access: write
+    - team: toi
+      application: rekrutteringsbistand-kandidatvarsel-api
+      access: write

--- a/dev-gcp/aapen-varsel-hendelse.yaml
+++ b/dev-gcp/aapen-varsel-hendelse.yaml
@@ -31,3 +31,6 @@ spec:
     - team: min-side
       application: tms-brannslukning
       access: read
+    - team: toi
+      application: rekrutteringsbistand-kandidatvarsel-api
+      access: read


### PR DESCRIPTION
Tilgang til både aapen-brukervarsel og aapen-varsel-hendelse for å både opprette og kunne informere veileder om ekstern varsel ble sendt.

Kommer med PR for prod senere.