### PR TITLE
Ga paw-arbsokreg-bekreftelse tilgang til varsel topic i dev

### DIFF
--- a/dev-gcp/aapen-brukervarsel.yaml
+++ b/dev-gcp/aapen-brukervarsel.yaml
@@ -114,3 +114,6 @@ spec:
     - team: amt
       application: amt-distribusjon
       access: write
+    - team: paw
+      application: paw-arbeidssoekerregisteret-bekreftelse-min-side-varsler
+      access: write


### PR DESCRIPTION
La til paw-arbeidssoekerregisteret-bekreftelse-min-side-varsler i acl for aapen-brukervarsel-v1. 
Dette er en ny tjeneste for funksjonalitet som vil erstatte dagens meldekort for arbeidssøkere uten ytelser.