### PR TITLE
Rename ung-brukerdialog -> ung-brukerdialog-api

### DIFF
--- a/dev-gcp/aapen-brukervarsel.yaml
+++ b/dev-gcp/aapen-brukervarsel.yaml
@@ -154,7 +154,7 @@ spec:
       application: ung-deltakelse-opplyser
       access: write
     - team: k9saksbehandling
-      application: ung-brukerdialog
+      application: ung-brukerdialog-api
       access: write
     - team: poao
       application: veilarboppfolging

--- a/prod-gcp/aapen-brukervarsel.yaml
+++ b/prod-gcp/aapen-brukervarsel.yaml
@@ -142,7 +142,7 @@ spec:
       application: ung-deltakelse-opplyser
       access: write
     - team: k9saksbehandling
-      application: ung-brukerdialog
+      application: ung-brukerdialog-api
       access: write
     - team: poao
       application: veilarboppfolging


### PR DESCRIPTION
Eksisterer enda ikkje i produksjon.